### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Change Log
+
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Pack which allows integration with [CubeSensors](https://cubesensors.com/) servi
 * ``sensor.device_uid`` - A list of device UIDs for which you want to retrieve the measurements
   for.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Obtaining API credentials
 
 To obtain the API credentials you first need to request API access as described

--- a/actions/get_device.yaml
+++ b/actions/get_device.yaml
@@ -1,5 +1,5 @@
 name: get_device
-runner_type: run-python
+runner_type: python-script
 description: Retrieve details for a particular device (cube).
 enabled: true
 entry_point: get_device.py

--- a/actions/get_measurements.yaml
+++ b/actions/get_measurements.yaml
@@ -1,5 +1,5 @@
 name: get_measurements
-runner_type: run-python
+runner_type: python-script
 description: Retrieve current measurements for a particular device (cube).
 enabled: true
 entry_point: get_measurements.py

--- a/actions/list_devices.yaml
+++ b/actions/list_devices.yaml
@@ -1,5 +1,5 @@
 name: list_devices
-runner_type: run-python
+runner_type: python-script
 description: List information about all the available devices (cubes).
 enabled: true
 entry_point: list_devices.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,6 +9,6 @@ keywords:
   - sensors
   - probes
   - home automation
-version : 0.2.0
+version : 0.3.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.